### PR TITLE
Let devicemapper work on stable rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,11 @@
 language: rust
-rust: nightly
+rust:
+  - stable
+  - beta
+  - nightly
+script:
+  - cargo build --verbose && cargo test --verbose
+  - |
+    [ $TRAVIS_RUST_VERSION != nightly ] ||
+    ( cargo build --verbose --no-default-features --features nightly &&
+      cargo test --verbose --no-default-features --features nightly )

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,15 +9,23 @@ repository = "https://github.com/agrover/devicemapper-rs"
 readme = "README.md"
 keywords = ["Linux", "device", "mapper", "libdm", "storage"]
 license = "MPL-2.0"
+build = "build.rs"
 
 [[bin]]
 name = "dmtest"
 path = "src/bin/dmtest.rs"
+
+[features]
+default = ["serde_codegen"]
+nightly = ["serde_macros", "clippy"]
+
+[build-dependencies]
+serde_codegen = { version = "*", optional = true }
 
 [dependencies]
 libc = "0.2"
 nix = "0.5"
 bitflags = "0.4"
 serde = "0.7"
-serde_macros = "0.7"
-clippy = "0"
+serde_macros = { version = "0.7", optional = true }
+clippy = { version = "0", optional = true }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,25 @@
+#[cfg(not(feature = "serde_macros"))]
+mod inner {
+    extern crate serde_codegen;
+
+    use std::env;
+    use std::path::Path;
+
+    pub fn main() {
+        let out_dir = env::var_os("OUT_DIR").unwrap();
+
+        let src = Path::new("src/device.rs.in");
+        let dst = Path::new(&out_dir).join("device.rs");
+
+        serde_codegen::expand(&src, &dst).unwrap();
+    }
+}
+
+#[cfg(feature = "serde_macros")]
+mod inner {
+    pub fn main() {}
+}
+
+fn main() {
+    inner::main();
+}

--- a/src/device.rs.in
+++ b/src/device.rs.in
@@ -1,0 +1,10 @@
+/// A struct containing the device's major and minor numbers
+///
+/// Also allows conversion to/from a single 64bit value.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Serialize, Deserialize)]
+pub struct Device {
+    /// Device major number
+    pub major: u32,
+    /// Device minor number
+    pub minor: u8,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,9 +36,13 @@
 //! Devices have "active" and "inactive" mapping tables. See function
 //! descriptions for which table they affect.
 
-#![feature(custom_derive, plugin)]
-#![plugin(serde_macros)]
-#![plugin(clippy)]
+#![cfg_attr(feature = "serde_macros", feature(custom_derive, plugin))]
+#![cfg_attr(feature = "serde_macros", plugin(serde_macros))]
+
+#![cfg_attr(feature = "clippy", feature(plugin))]
+#![cfg_attr(feature = "clippy", plugin(clippy))]
+#![cfg_attr(not(feature = "clippy"), allow(unknown_lints))]
+
 #![warn(missing_docs)]
 
 #![allow(used_underscore_binding)]
@@ -132,16 +136,14 @@ bitflags!(
 );
 
 
-/// A struct containing the device's major and minor numbers
-///
-/// Also allows conversion to/from a single 64bit value.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Serialize, Deserialize)]
-pub struct Device {
-    /// Device major number
-    pub major: u32,
-    /// Device minor number
-    pub minor: u8,
+mod device {
+    #[cfg(feature = "serde_macros")]
+    include!("device.rs.in");
+
+    #[cfg(not(feature = "serde_macros"))]
+    include!(concat!(env!("OUT_DIR"), "/device.rs"));
 }
+pub use device::Device;
 
 impl Device {
     /// Returns the path in `/dev` that corresponds with the device number.


### PR DESCRIPTION
Serde's serialization traits can be "derived" in a build script using
serde_codegen.  This patch follows serde's example to make device.rs.in
which can be built either way, with serde_macros or serde_codegen.

Clippy is nice to have, but entirely optional.

The default feature set is now compatible with stable rust.  To enable
both serde_macros and clippy features at once, use:
     cargo build --no-default-features --features nightly

Signed-off-by: Josh Stone <jistone@redhat.com>