### PR TITLE
Let devicemapper work on stable rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,11 @@
 language: rust
-rust: nightly
+rust:
+  - stable
+  - beta
+  - nightly
+script:
+  - cargo build --verbose && cargo test --verbose
+  - |
+    [ $TRAVIS_RUST_VERSION != nightly ] ||
+    ( cargo build --verbose --features clippy &&
+      cargo test --verbose --features clippy )

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "devicemapper"
-version = "0.3.6"
+version = "0.4.0"
 authors = ["Andy Grover <agrover@redhat.com>"]
 description = "A library for using Linux device mapper"
 documentation = "http://agrover.github.io/devicemapper-rs/doc/devicemapper/index.html"
@@ -18,6 +18,4 @@ path = "src/bin/dmtest.rs"
 libc = "0.2"
 nix = "0.5"
 bitflags = "0.4"
-serde = "0.7"
-serde_macros = "0.7"
-clippy = "0"
+clippy = { version = "0", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,9 +36,10 @@
 //! Devices have "active" and "inactive" mapping tables. See function
 //! descriptions for which table they affect.
 
-#![feature(custom_derive, plugin)]
-#![plugin(serde_macros)]
-#![plugin(clippy)]
+#![cfg_attr(feature = "clippy", feature(plugin))]
+#![cfg_attr(feature = "clippy", plugin(clippy))]
+#![cfg_attr(not(feature = "clippy"), allow(unknown_lints))]
+
 #![warn(missing_docs)]
 
 #![allow(used_underscore_binding)]
@@ -47,7 +48,6 @@
 extern crate libc;
 #[macro_use]
 extern crate nix;
-extern crate serde;
 
 #[macro_use]
 extern crate bitflags;
@@ -135,7 +135,7 @@ bitflags!(
 /// A struct containing the device's major and minor numbers
 ///
 /// Also allows conversion to/from a single 64bit value.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
 pub struct Device {
     /// Device major number
     pub major: u32,


### PR DESCRIPTION
- Make clippy optional; use `--features clippy` to enable it.
- Remove serialization from `Device`, and now serde isn't needed.
- Test stable, beta, and nightly in Travis CI.
- Bump semver due to the removed serialization.

Signed-off-by: Josh Stone <jistone@redhat.com>